### PR TITLE
Fix NamedType error in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,6 @@ jobs:
         uses: github/codeql-action/init@v3
       - name: Run tests
         run: |
-          ${{ steps.init.outputs.codeql-path }} test run ./cpp/test/
-          ${{ steps.init.outputs.codeql-path }} test run ./go/test/
-          ${{ steps.init.outputs.codeql-path }} test run ./java/test/
+          ${{ steps.init.outputs.codeql-path }} test run -v ./cpp/test/
+          ${{ steps.init.outputs.codeql-path }} test run -v ./go/test/
+          ${{ steps.init.outputs.codeql-path }} test run -v ./java/test/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ jobs:
         uses: github/codeql-action/init@v3
       - name: Run tests
         run: |
-          ${{ steps.init.outputs.codeql-path }} pack ci ./cpp/test/
-          ${{ steps.init.outputs.codeql-path }} test run -vv ./cpp/test/
-          ${{ steps.init.outputs.codeql-path }} pack ci ./go/test/
-          ${{ steps.init.outputs.codeql-path }} test run -vv ./go/test/
-          ${{ steps.init.outputs.codeql-path }} pack ci ./java/test/
-          ${{ steps.init.outputs.codeql-path }} test run -vv ./java/test/
+          ${{ steps.init.outputs.codeql-path }} test extract ./java/test/
+          ${{ steps.init.outputs.codeql-path }} query run --database=java/test/test.testproj/ -- java/src/security/Recursion/Recursion.ql
+          ${{ steps.init.outputs.codeql-path }} test run ./java/test/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ jobs:
         uses: github/codeql-action/init@v3
       - name: Run tests
         run: |
+          ${{ steps.init.outputs.codeql-path }} pack ci ./cpp/test/
           ${{ steps.init.outputs.codeql-path }} test run -v ./cpp/test/
+          ${{ steps.init.outputs.codeql-path }} pack ci ./go/test/
           ${{ steps.init.outputs.codeql-path }} test run -v ./go/test/
+          ${{ steps.init.outputs.codeql-path }} pack ci ./java/test/
           ${{ steps.init.outputs.codeql-path }} test run -v ./java/test/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Run tests
         run: |
           ${{ steps.init.outputs.codeql-path }} pack ci ./cpp/test/
-          ${{ steps.init.outputs.codeql-path }} test run -v ./cpp/test/
+          ${{ steps.init.outputs.codeql-path }} test run -vv ./cpp/test/
           ${{ steps.init.outputs.codeql-path }} pack ci ./go/test/
-          ${{ steps.init.outputs.codeql-path }} test run -v ./go/test/
+          ${{ steps.init.outputs.codeql-path }} test run -vv ./go/test/
           ${{ steps.init.outputs.codeql-path }} pack ci ./java/test/
-          ${{ steps.init.outputs.codeql-path }} test run -v ./java/test/
+          ${{ steps.init.outputs.codeql-path }} test run -vv ./java/test/

--- a/go/src/security/MissingMinVersionTLS/MissingMinVersionTLS.ql
+++ b/go/src/security/MissingMinVersionTLS/MissingMinVersionTLS.ql
@@ -94,12 +94,12 @@ predicate configOrConfigPointer(Type t) {
     ) or 
     exists(Type tp | 
         tp.hasQualifiedName("crypto/tls", "Config") and
-        t.(NamedType).getUnderlyingType().(StructType).hasField(_, tp)
+        t.(DefinedType).getUnderlyingType().(StructType).hasField(_, tp)
     ) or 
     exists(Type tp, Type tp2 | 
         tp.hasQualifiedName("crypto/tls", "Config") and
         tp2 = tp.getPointerType+() and
-        t.(NamedType).getUnderlyingType().(StructType).hasField(_, tp2)
+        t.(DefinedType).getUnderlyingType().(StructType).hasField(_, tp2)
     )
 }
 

--- a/java/src/codeql-pack.lock.yml
+++ b/java/src/codeql-pack.lock.yml
@@ -2,27 +2,27 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/dataflow:
-    version: 1.1.5
+    version: 2.0.4
   codeql/java-all:
-    version: 4.2.0
+    version: 7.1.2
   codeql/mad:
-    version: 1.0.11
+    version: 1.0.20
   codeql/rangeanalysis:
-    version: 1.0.11
+    version: 1.0.20
   codeql/regex:
-    version: 1.0.11
+    version: 1.0.20
   codeql/ssa:
-    version: 1.0.11
+    version: 1.0.20
   codeql/threat-models:
-    version: 1.0.11
+    version: 1.0.20
   codeql/tutorial:
-    version: 1.0.11
+    version: 1.0.20
   codeql/typeflow:
-    version: 1.0.11
+    version: 1.0.20
   codeql/typetracking:
-    version: 1.0.11
+    version: 2.0.4
   codeql/util:
-    version: 1.0.11
+    version: 2.0.7
   codeql/xml:
-    version: 1.0.11
+    version: 1.0.20
 compiled: false

--- a/java/test/codeql-pack.lock.yml
+++ b/java/test/codeql-pack.lock.yml
@@ -2,27 +2,27 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/dataflow:
-    version: 1.1.5
+    version: 2.0.4
   codeql/java-all:
-    version: 4.2.0
+    version: 7.1.2
   codeql/mad:
-    version: 1.0.11
+    version: 1.0.20
   codeql/rangeanalysis:
-    version: 1.0.11
+    version: 1.0.20
   codeql/regex:
-    version: 1.0.11
+    version: 1.0.20
   codeql/ssa:
-    version: 1.0.11
+    version: 1.0.20
   codeql/threat-models:
-    version: 1.0.11
+    version: 1.0.20
   codeql/tutorial:
-    version: 1.0.11
+    version: 1.0.20
   codeql/typeflow:
-    version: 1.0.11
+    version: 1.0.20
   codeql/typetracking:
-    version: 1.0.11
+    version: 2.0.4
   codeql/util:
-    version: 1.0.11
+    version: 2.0.7
   codeql/xml:
-    version: 1.0.11
+    version: 1.0.20
 compiled: false


### PR DESCRIPTION
Fixes:

```
--- expected
+++ actual
@@ -1,3 +1,5 @@
+WARNING: type 'NamedType' has been deprecated and may be removed in future (MissingMinVersionTLS.ql:97,12-21)
+WARNING: type 'NamedType' has been deprecated and may be removed in future (MissingMinVersionTLS.ql:102,12-21)
 | MissingMinVersionTLS.go:25:14:25:25 | struct literal | TLS.Config.MinVersion is never set for variable $@  | MissingMinVersionTLS.go:25:3:25:8 | config | config |
 | MissingMinVersionTLS.go:35:14:37:3 | struct literal | TLS.Config.MinVersion is never set for variable $@  | MissingMinVersionTLS.go:35:3:35:8 | config | config |
 | MissingMinVersionTLS.go:50:13:50:24 | struct literal | TLS.Config.MinVersion is never set for variable $@  | MissingMinVersionTLS.go:50:3:50:8 | config | config |
```

https://codeql.github.com/docs/codeql-overview/codeql-changelog/codeql-cli-2.20.5/#id9