### PR TITLE
Update all pack dependencies

### DIFF
--- a/cpp/lib/codeql-pack.lock.yml
+++ b/cpp/lib/codeql-pack.lock.yml
@@ -1,10 +1,28 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/controlflow:
+    version: 2.0.22
   codeql/cpp-all:
-    version: 0.6.1
+    version: 6.1.3
+  codeql/dataflow:
+    version: 2.0.22
+  codeql/mad:
+    version: 1.0.38
+  codeql/quantum:
+    version: 0.0.16
+  codeql/rangeanalysis:
+    version: 1.0.38
   codeql/ssa:
-    version: 0.0.14
+    version: 2.0.14
   codeql/tutorial:
-    version: 0.0.7
+    version: 1.0.38
+  codeql/typeflow:
+    version: 1.0.38
+  codeql/typetracking:
+    version: 2.0.22
+  codeql/util:
+    version: 2.0.25
+  codeql/xml:
+    version: 1.0.38
 compiled: false

--- a/cpp/src/codeql-pack.lock.yml
+++ b/cpp/src/codeql-pack.lock.yml
@@ -1,24 +1,28 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/controlflow:
+    version: 2.0.22
   codeql/cpp-all:
-    version: 3.0.0
+    version: 6.1.3
   codeql/dataflow:
-    version: 1.1.7
+    version: 2.0.22
   codeql/mad:
-    version: 1.0.13
+    version: 1.0.38
+  codeql/quantum:
+    version: 0.0.16
   codeql/rangeanalysis:
-    version: 1.0.13
+    version: 1.0.38
   codeql/ssa:
-    version: 1.0.13
+    version: 2.0.14
   codeql/tutorial:
-    version: 1.0.13
+    version: 1.0.38
   codeql/typeflow:
-    version: 1.0.13
+    version: 1.0.38
   codeql/typetracking:
-    version: 1.0.13
+    version: 2.0.22
   codeql/util:
-    version: 2.0.0
+    version: 2.0.25
   codeql/xml:
-    version: 1.0.13
+    version: 1.0.38
 compiled: false

--- a/cpp/test/codeql-pack.lock.yml
+++ b/cpp/test/codeql-pack.lock.yml
@@ -1,24 +1,28 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/controlflow:
+    version: 2.0.22
   codeql/cpp-all:
-    version: 3.0.0
+    version: 6.1.3
   codeql/dataflow:
-    version: 1.1.7
+    version: 2.0.22
   codeql/mad:
-    version: 1.0.13
+    version: 1.0.38
+  codeql/quantum:
+    version: 0.0.16
   codeql/rangeanalysis:
-    version: 1.0.13
+    version: 1.0.38
   codeql/ssa:
-    version: 1.0.13
+    version: 2.0.14
   codeql/tutorial:
-    version: 1.0.13
+    version: 1.0.38
   codeql/typeflow:
-    version: 1.0.13
+    version: 1.0.38
   codeql/typetracking:
-    version: 1.0.13
+    version: 2.0.22
   codeql/util:
-    version: 2.0.0
+    version: 2.0.25
   codeql/xml:
-    version: 1.0.13
+    version: 1.0.38
 compiled: false

--- a/go/src/codeql-pack.lock.yml
+++ b/go/src/codeql-pack.lock.yml
@@ -1,20 +1,24 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/concepts:
+    version: 0.0.12
+  codeql/controlflow:
+    version: 2.0.22
   codeql/dataflow:
-    version: 1.1.7
+    version: 2.0.22
   codeql/go-all:
-    version: 3.0.0
+    version: 5.0.5
   codeql/mad:
-    version: 1.0.13
+    version: 1.0.38
   codeql/ssa:
-    version: 1.0.13
+    version: 2.0.14
   codeql/threat-models:
-    version: 1.0.13
+    version: 1.0.38
   codeql/tutorial:
-    version: 1.0.13
+    version: 1.0.38
   codeql/typetracking:
-    version: 1.0.13
+    version: 2.0.22
   codeql/util:
-    version: 2.0.0
+    version: 2.0.25
 compiled: false

--- a/go/src/security/MissingMinVersionTLS/MissingMinVersionTLS.ql
+++ b/go/src/security/MissingMinVersionTLS/MissingMinVersionTLS.ql
@@ -62,7 +62,12 @@ module TlsConfigCreationConfig implements DataFlow::ConfigSig {
   /**
    * Holds if it is TLS.Config instance (a Variable).
    */
-  predicate isSink(DataFlow::Node sink) { exists(Variable v | sink.asExpr() = v.getAReference()) }
+  predicate isSink(DataFlow::Node sink) {
+    exists(Variable v |
+      sink.asExpr() = v.getAReference() or
+      sink.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr() = v.getAReference()
+    )
+  }
 
   /**
    * Holds if TLS.Config literal is saved in a structure's field
@@ -87,13 +92,13 @@ predicate configOrConfigPointer(Type t) {
   or
   exists(Type tp |
     tp.hasQualifiedName("crypto/tls", "Config") and
-    t.(NamedType).getUnderlyingType().(StructType).hasField(_, tp)
+    t.(DefinedType).getUnderlyingType().(StructType).hasField(_, tp)
   )
   or
   exists(Type tp, Type tp2 |
     tp.hasQualifiedName("crypto/tls", "Config") and
     tp2 = tp.getPointerType+() and
-    t.(NamedType).getUnderlyingType().(StructType).hasField(_, tp2)
+    t.(DefinedType).getUnderlyingType().(StructType).hasField(_, tp2)
   )
 }
 
@@ -225,7 +230,10 @@ where
   // find tls.Config structures with MinVersion not set on the structure initialization
   (
     TlsConfigCreationFlow::flow(source, sink) and
-    sink.asExpr() = v.getAReference() and
+    (
+      sink.asExpr() = v.getAReference() or
+      sink.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr() = v.getAReference()
+    ) and
     source.asExpr() = configStruct
   ) and
   // only explicitely defined, e.g., skip function arguments

--- a/go/test/codeql-pack.lock.yml
+++ b/go/test/codeql-pack.lock.yml
@@ -1,20 +1,24 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/concepts:
+    version: 0.0.12
+  codeql/controlflow:
+    version: 2.0.22
   codeql/dataflow:
-    version: 1.1.7
+    version: 2.0.22
   codeql/go-all:
-    version: 3.0.0
+    version: 5.0.5
   codeql/mad:
-    version: 1.0.13
+    version: 1.0.38
   codeql/ssa:
-    version: 1.0.13
+    version: 2.0.14
   codeql/threat-models:
-    version: 1.0.13
+    version: 1.0.38
   codeql/tutorial:
-    version: 1.0.13
+    version: 1.0.38
   codeql/typetracking:
-    version: 1.0.13
+    version: 2.0.22
   codeql/util:
-    version: 2.0.0
+    version: 2.0.25
 compiled: false

--- a/java/src/codeql-pack.lock.yml
+++ b/java/src/codeql-pack.lock.yml
@@ -1,28 +1,32 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/controlflow:
+    version: 2.0.22
   codeql/dataflow:
-    version: 1.1.5
+    version: 2.0.22
   codeql/java-all:
-    version: 4.2.0
+    version: 7.8.2
   codeql/mad:
-    version: 1.0.11
+    version: 1.0.38
+  codeql/quantum:
+    version: 0.0.16
   codeql/rangeanalysis:
-    version: 1.0.11
+    version: 1.0.38
   codeql/regex:
-    version: 1.0.11
+    version: 1.0.38
   codeql/ssa:
-    version: 1.0.11
+    version: 2.0.14
   codeql/threat-models:
-    version: 1.0.11
+    version: 1.0.38
   codeql/tutorial:
-    version: 1.0.11
+    version: 1.0.38
   codeql/typeflow:
-    version: 1.0.11
+    version: 1.0.38
   codeql/typetracking:
-    version: 1.0.11
+    version: 2.0.22
   codeql/util:
-    version: 1.0.11
+    version: 2.0.25
   codeql/xml:
-    version: 1.0.11
+    version: 1.0.38
 compiled: false

--- a/java/test/codeql-pack.lock.yml
+++ b/java/test/codeql-pack.lock.yml
@@ -1,28 +1,32 @@
 ---
 lockVersion: 1.0.0
 dependencies:
+  codeql/controlflow:
+    version: 2.0.22
   codeql/dataflow:
-    version: 1.1.5
+    version: 2.0.22
   codeql/java-all:
-    version: 4.2.0
+    version: 7.8.2
   codeql/mad:
-    version: 1.0.11
+    version: 1.0.38
+  codeql/quantum:
+    version: 0.0.16
   codeql/rangeanalysis:
-    version: 1.0.11
+    version: 1.0.38
   codeql/regex:
-    version: 1.0.11
+    version: 1.0.38
   codeql/ssa:
-    version: 1.0.11
+    version: 2.0.14
   codeql/threat-models:
-    version: 1.0.11
+    version: 1.0.38
   codeql/tutorial:
-    version: 1.0.11
+    version: 1.0.38
   codeql/typeflow:
-    version: 1.0.11
+    version: 1.0.38
   codeql/typetracking:
-    version: 1.0.11
+    version: 2.0.22
   codeql/util:
-    version: 1.0.11
+    version: 2.0.25
   codeql/xml:
-    version: 1.0.11
+    version: 1.0.38
 compiled: false


### PR DESCRIPTION
Most queries updated without problems. However, `go/src/security/MissingMinVersionTLS/MissingMinVersionTLS.ql` took some consideration.

First, the `NamedType` updates fixed this warning:

```
+WARNING: type 'NamedType' has been deprecated and may be removed in future (MissingMinVersionTLS.ql:90,8-17)
+WARNING: type 'NamedType' has been deprecated and may be removed in future (MissingMinVersionTLS.ql:96,8-17)
```

Second, the `sink.(DataFlow::PostUpdateNode).getPreUpdateNode()` changes were due to this breaking change in the `codeql/go-all` library: https://github.com/github/codeql/blob/codeql-cli/latest/go/ql/lib/CHANGELOG.md#500.

Specifically:

> The shape of the Go data-flow graph has changed. Previously for code like x := def(); use1(x); use2(x), there would be edges from the definition of x to each use. Now there is an edge from the definition to the first use, then another from the first use to the second, and so on. This means that data-flow barriers work differently - flow will not reach any uses after the barrier node. Where this is not desired it may be necessary to add an additional flow step to propagate the flow forward. Additionally, when a variable may be subject to a side-effect, such as updating an array, passing a pointer to a function that might write through it or writing to a field of a struct, there is now a dedicated post-update node representing the variable after this side-effect has taken place. Previously post-update nodes were aliases for either a variable's definition, or were equal to the pre-update node. This led to backwards steps in the data-flow graph, which could cause false positives. For example, in the previous code there would be an edge from x in use2(x) back to the definition of x. If we define our sources as any argument of use2 and our sinks as any argument of use1 then this would lead to a false positive path. Now there are distinct post-update nodes and no backwards edge to the definition, so we will not find this false positive path.

Shoutout to @owen-mc for helping me out here.