### PR TITLE
Explicit precedence clarifies logic in UseOfLegacyAlgorithm.ql

### DIFF
--- a/cpp/src/crypto/UseOfLegacyAlgorithm.ql
+++ b/cpp/src/crypto/UseOfLegacyAlgorithm.ql
@@ -36,9 +36,10 @@ where
      * 			descend
      * 			destroy
      */
-
-    cipherName = "DES" and
-    functionName.regexpMatch(".*(?<!no|mo|co)des(?!cri(be|ption|ptor)|ign|cend|troy).*")
+    (
+      cipherName = "DES" and
+      functionName.regexpMatch(".*(?<!no|mo|co)des(?!cri(be|ption|ptor)|ign|cend|troy).*")
+    )
   )
 select call.getLocation(),
   "Potential use of legacy cryptographic algorithm " + cipherName + " detected in function name " +


### PR DESCRIPTION
The logic in UseOfLegacyAlgorithm.ql current has bare and/or for the DES special-case, which is ambiguous if you don't know what CodeQL's conjunction/disjunction operator precedence is. The code is correct, but this PR adds parens to make it explicit and avoid confusion.